### PR TITLE
Bring in patches from the port (mostly).

### DIFF
--- a/lib/libpam/modules/Makefile.inc
+++ b/lib/libpam/modules/Makefile.inc
@@ -1,4 +1,7 @@
 # Include Makefiles from $SRCDIR
 
-.include </usr/src/lib/libpam/modules/Makefile.inc>
+LIBDIR=${PREFIX}/lib
 
+SYSDIR?=	/usr/src/sys
+
+.include <${SYSDIR}/../lib/libpam/modules/Makefile.inc>

--- a/lib/libpam/modules/pam_pefs/Makefile
+++ b/lib/libpam/modules/pam_pefs/Makefile
@@ -29,3 +29,6 @@ LDADD= -lutil
 .PATH: ${SYS}/crypto
 .PATH: ${SYS}/crypto/rijndael
 .PATH: ${SYS}/crypto/hmac ${SYS}/crypto/pbkdf2 ${SYS}/crypto/sha2
+
+# Fix build without OBJDIR for shared components
+.NOPATH: ${OBJS}

--- a/sys/fs/pefs/pefs_aesni.h
+++ b/sys/fs/pefs/pefs_aesni.h
@@ -26,6 +26,8 @@
  * $FreeBSD$
  */
 
+#ifdef PEFS_AESNI
+
 #include <crypto/aesni/aesni.h>
 
 struct pefs_aesni_ctx {
@@ -41,3 +43,5 @@ struct pefs_aesni_ses {
 	u_int			fpu_cpuid;
 	int			fpu_saved;
 };
+
+#endif

--- a/sys/modules/pefs/Makefile
+++ b/sys/modules/pefs/Makefile
@@ -13,7 +13,7 @@ SRCS=	vnode_if.h \
 	pefs_xts.c vmac.c \
 	crypto_verify_bytes.c hmac_sha512.c sha512c.c
 
-.if ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "amd64"
+.if (${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "amd64") && !defined(PEFS_AESNI_DISABLE)
 SRCS+=	pefs_aesni.c
 CFLAGS+= -DPEFS_AESNI
 .endif


### PR DESCRIPTION
However, compile AESNI for x86 unless explicitly disabled.